### PR TITLE
Fix typo in help with hex values

### DIFF
--- a/ss7calc.py
+++ b/ss7calc.py
@@ -24,7 +24,7 @@ help_message = '''Usage:
    set Signaling Point Code as 5-4-5 Format
 "-i", "--int"
     set Signaling Point Code as decimal format
-"-h", "--hex"
+"-x", "--hex"
     set Signaling Point Code as heximal format 
 "-u", "--itu"
     specify SPC as ITU


### PR DESCRIPTION
Before

"-h", "--hex"
    set Signaling Point Code as heximal format 

in poll request 

"-x", "--hex"
    set Signaling Point Code as heximal format 
